### PR TITLE
add the ability to toggle refresh on methods that mutate the resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 isort = isort hsclient tests
 black = black -S -l 120 --target-version py38 hsclient tests
 
+
 .PHONY: format
 format:
 	$(isort)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 isort = isort hsclient tests
 black = black -S -l 120 --target-version py38 hsclient tests
 
-
 .PHONY: format
 format:
 	$(isort)

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ docs-serve:
 
 .PHONY: test
 test:
-	pytest -n 2 tests
+	pytest -n 4 tests
 
 .PHONY: test-cov
 test-cov:
-	pytest -n 2 --cov=hsclient --cov-report html
+	pytest -n 4 --cov=hsclient --cov-report html

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ docs-serve:
 
 .PHONY: test
 test:
-	pytest -n 4 tests
+	pytest -n 2 tests
 
 .PHONY: test-cov
 test-cov:
-	pytest -n 4 --cov=hsclient --cov-report html
+	pytest -n 2 --cov=hsclient --cov-report html

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -577,16 +577,19 @@ class Resource(Aggregation):
         self._hs_session.post(zip_path, status_code=200, data=data)
 
     @refresh
-    def file_unzip(self, path: str) -> None:
+    def file_unzip(self, path: str, overwrite: bool = True, ingest_metadata=True) -> None:
         """
         Unzips a file on HydroShare
         :param path: The path to the file to unzip
+        :param overwrite: Defaults to True, set to False to unzip the files into a folder with the zip filename
+        :param ingest_metadata: Defaults to True, set to False to not ingest HydroShare RDF metadata xml files
         :return: None
         """
         if not path.endswith(".zip"):
             raise Exception("File {} is not a zip, and cannot be unzipped".format(path))
         unzip_path = urljoin(self._hsapi_path, "functions", "unzip", "data", "contents", path)
-        self._hs_session.post(unzip_path, status_code=200, data={"overwrite": "true", "ingest_metadata": "true"})
+        self._hs_session.post(unzip_path, status_code=200,
+                              data={"overwrite": overwrite, "ingest_metadata": ingest_metadata})
 
     def file_aggregate(self, path: str, agg_type: AggregationType, refresh: bool = True):
         """

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -6,9 +6,9 @@ import tempfile
 import time
 from datetime import datetime
 from functools import wraps
-from posixpath import join as urljoin, splitext, basename, dirname
+from posixpath import basename, dirname, join as urljoin, splitext
 from typing import Dict, List, Union
-from urllib.parse import urlparse, quote, unquote
+from urllib.parse import quote, unquote, urlparse
 from zipfile import ZipFile
 
 import pandas
@@ -75,6 +75,7 @@ def refresh(f):
     The docstring of a decorated method is updated to include
     :param refresh: Defaults True, False to not refresh metadata from HydroShare
     """
+
     @wraps(f)
     def wrapper(*args, **kwargs):
         self = args[0]
@@ -88,10 +89,7 @@ def refresh(f):
 
     # update docstring to include refresh parameter
     doc_lines = f.__doc__.split("\n")
-    if doc_lines[-2].strip().startswith(":return:"):
-        insert_index = len(doc_lines) - 2
-    else:
-        insert_index = len(doc_lines) - 1
+    insert_index = len(doc_lines) - 2
     doc_lines.insert(insert_index, ":param refresh: Defaults True, False to not refresh metadata from HydroShare")
     wrapper.__doc__ = "\n    ".join([l.strip() for l in doc_lines])
 


### PR DESCRIPTION
Adds a decorator to refresh metadata from HydroShare after the function is called.  The decorator includes a parameter to toggle the refresh functionality.  This will be useful for making multiple updates to HydroShare without waiting for the metadata to be refreshed betwen calls.