### PR TITLE
Resource object instances returned by HydroShare object are memcached

### DIFF
--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -796,7 +796,7 @@ class HydroShare:
             if username or password:
                 self.my_user_info()  # validate credentials
 
-        self._resource_object_cache: Dict[str, Resource]= dict()
+        self._resource_object_cache: Dict[str, Resource] = dict()
 
     def sign_in(self) -> None:
         """Prompts for username/password.  Useful for avoiding saving your HydroShare credentials to a notebook"""

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -796,6 +796,8 @@ class HydroShare:
             if username or password:
                 self.my_user_info()  # validate credentials
 
+        self._resource_object_cache = dict()
+
     def sign_in(self) -> None:
         """Prompts for username/password.  Useful for avoiding saving your HydroShare credentials to a notebook"""
         username = input("Username: ").strip()
@@ -905,9 +907,14 @@ class HydroShare:
         :param validate: Defaults to True, set to False to not validate the resource exists
         :return: A Resource object representing a resource on HydroShare
         """
+        if resource_id in self._resource_object_cache:
+            return self._resource_object_cache[resource_id]
+
         res = Resource("/resource/{}/data/resourcemap.xml".format(resource_id), self._hs_session)
         if validate:
             res.metadata
+
+        self._resource_object_cache[resource_id] =  res
         return res
 
     def create(self) -> Resource:

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -905,6 +905,9 @@ class HydroShare:
         Creates a resource object from HydroShare with the provided resource_id
         :param resource_id: The resource id of the resource to retrieve
         :param validate: Defaults to True, set to False to not validate the resource exists
+        :param use_cache: Defaults to True, set to False to skip the cache, and always retrieve the
+            resource from HydroShare. This parameter also does not cache the retrieved Resource
+            object.
         :return: A Resource object representing a resource on HydroShare
         """
         if resource_id in self._resource_object_cache and use_cache:

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -924,6 +924,9 @@ class HydroShare:
     def create(self, use_cache: bool = True) -> Resource:
         """
         Creates a new resource on HydroShare
+        :param use_cache: Defaults to True, set to False to skip the cache, and always retrieve the
+            resource from HydroShare. This parameter also does not cache the retrieved Resource
+            object.
         :return: A Resource object representing a resource on HydroShare
         """
         response = self._hs_session.post('/hsapi/resource/', status_code=201)

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -921,14 +921,14 @@ class HydroShare:
             self._resource_object_cache[resource_id] =  res
         return res
 
-    def create(self) -> Resource:
+    def create(self, use_cache: bool = True) -> Resource:
         """
         Creates a new resource on HydroShare
         :return: A Resource object representing a resource on HydroShare
         """
         response = self._hs_session.post('/hsapi/resource/', status_code=201)
         resource_id = response.json()['resource_id']
-        return self.resource(resource_id)
+        return self.resource(resource_id, use_cache=use_cache)
 
     def user(self, user_id: int) -> User:
         """

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -796,7 +796,7 @@ class HydroShare:
             if username or password:
                 self.my_user_info()  # validate credentials
 
-        self._resource_object_cache: Dict[str, Resource] = dict()
+        self._resource_object_cache: Dict[str, Resource]= dict()
 
     def sign_in(self) -> None:
         """Prompts for username/password.  Useful for avoiding saving your HydroShare credentials to a notebook"""

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -796,7 +796,7 @@ class HydroShare:
             if username or password:
                 self.my_user_info()  # validate credentials
 
-        self._resource_object_cache = dict()
+        self._resource_object_cache: Dict[str, Resource]= dict()
 
     def sign_in(self) -> None:
         """Prompts for username/password.  Useful for avoiding saving your HydroShare credentials to a notebook"""

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -900,21 +900,22 @@ class HydroShare:
             for item in results:
                 yield ResourcePreview(**item)
 
-    def resource(self, resource_id: str, validate: bool = True) -> Resource:
+    def resource(self, resource_id: str, validate: bool = True, use_cache: bool = True) -> Resource:
         """
         Creates a resource object from HydroShare with the provided resource_id
         :param resource_id: The resource id of the resource to retrieve
         :param validate: Defaults to True, set to False to not validate the resource exists
         :return: A Resource object representing a resource on HydroShare
         """
-        if resource_id in self._resource_object_cache:
+        if resource_id in self._resource_object_cache and use_cache:
             return self._resource_object_cache[resource_id]
 
         res = Resource("/resource/{}/data/resourcemap.xml".format(resource_id), self._hs_session)
         if validate:
             res.metadata
 
-        self._resource_object_cache[resource_id] =  res
+        if use_cache:
+            self._resource_object_cache[resource_id] =  res
         return res
 
     def create(self) -> Resource:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -224,7 +224,7 @@ def test_resource_cached_by_HydroShare_instance_slow(hydroshare, new_resource):
     res2 = hydroshare.resource(res_id)
     assert id(hydroshare._resource_object_cache[res_id]) == id(res2)
 
-def test_resource_cached_by_HydroShare_instance(hydroshare, monkeypatch):
+def test_resource_cached_by_HydroShare_instances(hydroshare, monkeypatch):
     """ Monkeypatch resource to avoid hitting HydroShare.
     Verify resource object is present in resource object cache.
     """

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -214,6 +214,30 @@ def test_resource_delete(hydroshare, new_resource):
     except Exception as e:
         assert f"No resource was found for resource id:{res_id}" in str(e)
 
+def test_resource_cached_by_HydroShare_instance_slow(hydroshare, new_resource):
+    """ Verify resource object is present in resource object cache. """
+    res_id = new_resource.resource_id
+    res = hydroshare.resource(res_id)
+
+    assert res_id in hydroshare._resource_object_cache
+    assert id(hydroshare._resource_object_cache[res_id]) == id(res)
+    res2 = hydroshare.resource(res_id)
+    assert id(hydroshare._resource_object_cache[res_id]) == id(res2)
+
+def test_resource_cached_by_HydroShare_instance(hydroshare, monkeypatch):
+    """ Monkeypatch resource to avoid hitting HydroShare.
+    Verify resource object is present in resource object cache.
+    """
+    from hsclient import Resource
+    res_id = "fakeresource"
+    monkeypatch.setattr(Resource, "metadata", lambda: None)
+
+    res = hydroshare.resource(res_id)
+
+    assert res_id in hydroshare._resource_object_cache
+    assert id(hydroshare._resource_object_cache[res_id]) == id(res)
+    res2 = hydroshare.resource(res_id)
+    assert id(hydroshare._resource_object_cache[res_id]) == id(res2)
 
 def test_files_aggregations(resource):
     assert len(resource.files()) == 1


### PR DESCRIPTION
It may be desirable for a `Resource` returned by `HydroShare.resource(...)` be memcached in the `HydroShare` instance. This means any metadata retrieved and cached at the `Resource` object level are maintained in memory through a reference in the `HydroShare` instance. Here, this is implemented through a dictionary, `HydroShare._resource_object_cache`. 

There are two downsides (that I can think of) to this implementation that should be considered:

1. `HydroShare.resource(...)` now is not thread safe. One could argue it was not thread safe previously as it passes a reference to a mutable `HydroShareSession`object, but for the most part, that object should be read only.
2. Introduces complexity in managing references. Meaning, if a user wanted the garbage collector to destroy a `Resource` instantiated via `HydroShare.resource(...)`, they would have to remove the key value pair from the `HydroShare._resource_object_cache` dictionary. I don't think this is really an issue, but I wanted to mention it as it is an assumption the software is now imposing.