### PR TITLE
Run PR tests against beta

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,7 +6,7 @@ name: Python package
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -17,7 +17,7 @@ def change_test_dir(request):
 
 @pytest.fixture()
 def hydroshare(change_test_dir):
-    hs = HydroShare(os.getenv("HYDRO_USERNAME"), os.getenv("HYDRO_PASSWORD"))
+    hs = HydroShare(os.getenv("HYDRO_USERNAME"), os.getenv("HYDRO_PASSWORD"), host="beta.hydroshare.org")
     return hs
 
 


### PR DESCRIPTION
This PR updates the functional tests to run against beta.hydroshare.org.  It also updates the github action workflow to use the pull_request_target to test the merge of the PR with the base branch.  This will also allow us to use github secrets in Actions triggered by PRs from forks.

https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/