### PR TITLE
ResourcePreview authors now defaults to empty list if not supplied or None/null

### DIFF
--- a/hsclient/json_models.py
+++ b/hsclient/json_models.py
@@ -20,7 +20,7 @@ class ResourcePreview(BaseModel):
     resource_title: str = None
     resource_id: str = None
     abstract: str = None
-    authors: List[str] = None
+    authors: List[str] = []
     creator: str = None
     doi: str = None
     date_created: str = None
@@ -37,5 +37,5 @@ class ResourcePreview(BaseModel):
 
     @validator("authors", pre=True)
     def handle_null_author(cls, v):
-        if v is None:
-            return []
+        # return empty list when supplied authors field is None.
+        return [] if v is None else v

--- a/tests/test_json_models.py
+++ b/tests/test_json_models.py
@@ -1,0 +1,16 @@
+from hsclient.json_models import ResourcePreview
+
+
+def test_resource_preview_authors_field_default_is_empty_list():
+    """verify all `authors` fields are instantiated with [] values."""
+    test_data_dict = {"authors": None}
+    test_data_json = '{"authors": null}'
+
+    base_case = ResourcePreview()
+    from_kwargs = ResourcePreview(**test_data_dict)
+    from_dict = ResourcePreview.parse_obj(test_data_dict)
+    from_json = ResourcePreview.parse_raw(test_data_json)
+
+    assert all(
+        [x.authors == [] for x in [base_case, from_kwargs, from_dict, from_json]]
+    )


### PR DESCRIPTION
`ResourcePreview` `authors` field is now forced to default to an empty list (`[]`), if field is not supplied or `None` / `null` is supplied as value.  These changes follow @sblack-usu's proposed solution to #23, 
> updating the default from None to an empty list makes sense to me.

A unit test is also added to verify the desired behavior.

fixes #23