### PR TITLE
HydroShareSession's username, password, client_id, and token are now keyword only args with None default

### DIFF
--- a/hsclient/__init__.py
+++ b/hsclient/__init__.py
@@ -1,1 +1,2 @@
 from hsclient.hydroshare import Aggregation, File, HydroShare, Resource
+from hsclient.oauth2_model import Token

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -865,7 +865,7 @@ class HydroShare:
         protocol: str = default_protocol,
         port: int = default_port,
         client_id: str = None,
-        token: str = None,
+        token: Union[Token, Dict[str, str]]= None,
     ):
         if client_id or token:
             if not client_id or not token:

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -873,18 +873,22 @@ class HydroShare:
         self._hs_session.set_auth((username, password))
         self.my_user_info()  # validate credentials
 
-    def hs_juptyerhub(self, hs_auth_path="/home/jovyan/data/.hs_auth"):
+    @classmethod
+    def hs_juptyerhub(cls, hs_auth_path="/home/jovyan/data/.hs_auth"):
         """
-        Reads the OAuth2 client id and token from a Jupyterhub which uses HydroShare for authentication
-        :param hs_auth_path: Provide the path to the .hs_auth file if different than the default of
-        `/home/jovyan/data/.hs_auth`
+        Create a new HydroShare object using OAuth2 credentials stored in a canonical CUAHSI
+        Jupyterhub OAuth2 pickle file (stored at :param hs_auth_path:).
+
+        Provide a non-default (default: `/home/jovyan/data/.hs_auth`) path to the hs_auth file with
+        :param hs_auth_path:.
         """
         if not os.path.isfile(hs_auth_path):
             raise ValueError(f"hs_auth_path {hs_auth_path} does not exist.")
         with open(hs_auth_path, 'rb') as f:
             token, client_id = pickle.load(f)
-            self._hs_session.set_oauth(client_id, token)
-            self.my_user_info()  # validate credentials
+        instance = cls(client_id=client_id, token=token)
+        instance.my_user_info()  # validate credentials
+        return instance
 
     def search(
         self,

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -21,6 +21,7 @@ from requests_oauthlib import OAuth2Session
 
 from hsclient.json_models import ResourcePreview, User
 from hsclient.utils import attribute_filter, encode_resource_url, is_aggregation, main_file_type
+from hsclient.oauth2_model import Token
 
 
 class File(str):
@@ -699,7 +700,7 @@ class HydroShareSession:
         username: str = None,
         password: str = None,
         client_id: str = None,
-        token: str = None,
+        token: Union[Token, Dict[str, str]] = None,
     ):
         self._host = host
         self._protocol = protocol

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -7,6 +7,7 @@ import time
 from datetime import datetime
 from functools import wraps
 from posixpath import basename, dirname, join as urljoin, splitext
+from pprint import pformat
 from typing import Dict, List, Union
 from urllib.parse import quote, unquote, urlparse
 from zipfile import ZipFile
@@ -816,6 +817,20 @@ class HydroShareSession:
                 "Failed DELETE {}, status_code {}, message {}".format(url, response.status_code, response.content)
             )
         return response
+
+    @staticmethod
+    def _validate_oauth2_token(token: Union[Token, Dict[str, str]]) -> dict:
+        """Validate that object follows OAuth2 token specification. return dictionary representation
+        of OAuth2 token dropping optional fields that are None."""
+        if isinstance(token, dict) or isinstance(token, Token):
+            # try to coerce into Token model
+            o = Token.parse_obj(token)
+            # drop None fields from output
+            return o.dict(exclude_none=True)
+        else:
+            error_message = ("token must be hsclient.Token or dictionary following schema:\n"
+                            "{}".format(pformat(Token.__annotations__, sort_dicts=False)))
+            raise ValueError(error_message)
 
 
 class HydroShare:

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -712,6 +712,7 @@ class HydroShareSession:
             if not token or not client_id:
                 raise ValueError("Oauth2 requires both token and client_id be provided")
             else:
+                token = self._validate_oauth2_token(token)
                 self._session = OAuth2Session(client_id=client_id, token=token)
         else:
             if username is None or password is None:
@@ -724,7 +725,8 @@ class HydroShareSession:
             raise NotImplementedError(f"This session is an Oauth2 session and does not provide the set_oauth method")
         self._session.auth = auth
 
-    def set_oauth(self, client_id, token):
+    def set_oauth(self, client_id: str, token: Union[Token, Dict[str, str]]):
+        token = self._validate_oauth2_token(token)
         self._session = OAuth2Session(client_id=client_id, token=token)
 
     @property

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -712,6 +712,8 @@ class HydroShareSession:
             else:
                 self._session = OAuth2Session(client_id=client_id, token=token)
         else:
+            if username is None or password is None:
+                raise ValueError("Login requires either username and password or client_id and token be provided")
             self._session = requests.Session()
             self.set_auth((username, password))
 

--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -690,7 +690,17 @@ class Resource(Aggregation):
 
 
 class HydroShareSession:
-    def __init__(self, username, password, host, protocol, port, client_id=None, token=None):
+    def __init__(
+        self,
+        host,
+        protocol,
+        port,
+        *,
+        username: str = None,
+        password: str = None,
+        client_id: str = None,
+        token: str = None,
+    ):
         self._host = host
         self._protocol = protocol
         self._port = port

--- a/hsclient/oauth2_model.py
+++ b/hsclient/oauth2_model.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+# typing imports
+from typing import Optional
+
+# see rfc 6749 https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.2
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+    scope: Optional[str]
+    state: Optional[str]
+    expires_in: Optional[int]
+    refresh_token: Optional[str]
+
+    class Config:
+        # do not allow extra fields
+        extra = "forbid"


### PR DESCRIPTION
fixes #28

See #28 for context on the bug.

## Additions
- `Token` pydantic model that captures OAuth2 token specification ([rfc 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.2)). This is accessible at `hsclient` namespace level (i.e. `hsclient.Token`).


## Changes
- `HydroShare.hs_juptyerhub` now class method.
- `HydroShareSession`'s `username`, `password`, `client_id`, and `token` parameters now keyword only arguments.
- If no OAuth2 parameters provided, `ValueError` raised if `username` and `password` not provided to `HydroShareSession` constructor.
- OAuth2 `HydroShareSession` token's now have their structure validated using the `Token` model added in this PR. Helpful exception messages added to aid user. 