### PR TITLE
Handle User subject_areas field null case

### DIFF
--- a/hsclient/json_models.py
+++ b/hsclient/json_models.py
@@ -18,11 +18,9 @@ class User(BaseModel):
     subject_areas: List[str] = []
     date_joined: datetime = None
 
-    @validator('subject_areas', pre=True)
+    @validator("subject_areas", pre=True)
     def split_subject_areas(cls, value):
-        if value:
-            return value.split(", ")
-        return value
+        return value.split(", ") if value else []
 
 
 class ResourcePreview(BaseModel):

--- a/tests/test_json_models.py
+++ b/tests/test_json_models.py
@@ -21,6 +21,12 @@ def user(change_test_dir):
         return User(**json.loads(f.read()))
 
 
+def test_null_subject_areas():
+    fields = {"subject_areas": None}
+    o = User(**fields)
+    assert o.subject_areas == []
+
+
 def test_resource_preview_authors_field_default_is_empty_list():
     """verify all `authors` fields are instantiated with [] values."""
     test_data_dict = {"authors": None}


### PR DESCRIPTION
fix #33.

## Changes
- `User` model `subject_areas` now returns empty list if `null` is provided.

