### PR TITLE
Handle a wider range of None authors in ResourcePreview model

### DIFF
--- a/hsclient/json_models.py
+++ b/hsclient/json_models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from hsmodels.schemas.enums import UserIdentifierType
 from pydantic import AnyUrl, BaseModel, validator
@@ -48,5 +48,9 @@ class ResourcePreview(BaseModel):
         # return empty list when supplied authors field is None.
         if v is None:
             return []
-        # filter `None` authors
-        return list(filter(lambda item: item is not None, v))
+
+        # assert iterable non-string
+        assert isinstance(v, (Tuple, List))
+
+        # filter to remove all empty x's in v ("", None, or equivalent)
+        return list(filter(lambda x: x, v))

--- a/hsclient/json_models.py
+++ b/hsclient/json_models.py
@@ -46,4 +46,7 @@ class ResourcePreview(BaseModel):
     @validator("authors", pre=True)
     def handle_null_author(cls, v):
         # return empty list when supplied authors field is None.
-        return [] if v is None else v
+        if v is None:
+            return []
+        # filter `None` authors
+        return list(filter(lambda item: item is not None, v))

--- a/tests/test_json_models.py
+++ b/tests/test_json_models.py
@@ -31,17 +31,25 @@ AuthorsFieldResourcePreviewTestData = (
     json.dumps({"authors": None}),
     json.dumps({"authors": []}),
     json.dumps({"authors": [None]}),
+    json.dumps({"authors": [""]}),
+    json.dumps({"authors": [[]]}),
 )
 
 
 @pytest.mark.parametrize("test_data", AuthorsFieldResourcePreviewTestData)
-def test_resource_preview_authors_field_default_is_empty_list(test_data):
-    """verify all `authors` fields are instantiated with [] values."""
+def test_resource_preview_authors_field_handles_none_cases(test_data):
+    """verify all `authors` fields are instantiated with [] values.
 
-    base_case = ResourcePreview()
+    coerced `authors` field should be [] with following input:
+        None
+        []
+        [None]
+        [None, ""]
+    """
+
     from_json = ResourcePreview.parse_raw(test_data)
 
-    assert all([x.authors == [] for x in [base_case, from_json]])
+    assert from_json.authors == []
 
 
 def test_user_info(user):

--- a/tests/test_json_models.py
+++ b/tests/test_json_models.py
@@ -52,6 +52,16 @@ def test_resource_preview_authors_field_handles_none_cases(test_data):
     assert from_json.authors == []
 
 
+def test_resource_preview_authors_raises_validation_error_on_string_input():
+    """verify that a string passed to authors field raises pydantic.ValidationError"""
+    from pydantic import ValidationError
+
+    data = json.dumps({"authors": "should_fail"})
+
+    with pytest.raises(ValidationError):
+        ResourcePreview.parse_raw(data)
+
+
 def test_user_info(user):
     assert user.name == "Castronova, Anthony M."
     assert user.email == "castronova.anthony@gmail.com"

--- a/tests/test_json_models.py
+++ b/tests/test_json_models.py
@@ -27,17 +27,21 @@ def test_null_subject_areas():
     assert o.subject_areas == []
 
 
-def test_resource_preview_authors_field_default_is_empty_list():
+AuthorsFieldResourcePreviewTestData = (
+    json.dumps({"authors": None}),
+    json.dumps({"authors": []}),
+    json.dumps({"authors": [None]}),
+)
+
+
+@pytest.mark.parametrize("test_data", AuthorsFieldResourcePreviewTestData)
+def test_resource_preview_authors_field_default_is_empty_list(test_data):
     """verify all `authors` fields are instantiated with [] values."""
-    test_data_dict = {"authors": None}
-    test_data_json = '{"authors": null}'
 
     base_case = ResourcePreview()
-    from_kwargs = ResourcePreview(**test_data_dict)
-    from_dict = ResourcePreview.parse_obj(test_data_dict)
-    from_json = ResourcePreview.parse_raw(test_data_json)
+    from_json = ResourcePreview.parse_raw(test_data)
 
-    assert all([x.authors == [] for x in [base_case, from_kwargs, from_dict, from_json]])
+    assert all([x.authors == [] for x in [base_case, from_json]])
 
 
 def test_user_info(user):


### PR DESCRIPTION
Fixes #35 

This PR covers the case when an author is `None` in a list of authors. This is possible if a resource's author deletes their account, but others that have active accounts are still authors of the resource. This patch removes all `None` authors from a list of Authors. This PR covers and handles the following cases:


```python
authors=None # -> []
authors=[] # -> []
authors=[None] # -> []
authors=["some author", None] # -> ["some author"]
```