### PR TITLE
Instantiate HydroShare object without authorization

### DIFF
--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -716,12 +716,13 @@ class HydroShareSession:
                 token = self._validate_oauth2_token(token)
                 self._session = OAuth2Session(client_id=client_id, token=token)
         else:
-            if username is None or password is None:
-                raise ValueError("Login requires either username and password or client_id and token be provided")
-
             self._session = requests.Session()
             default_agent = self._session.headers['User-Agent']
             self._session.headers['User-Agent'] = default_agent + ' (hsclient)'
+
+            if username is None or password is None:
+                return
+
             self.set_auth((username, password))
 
     def set_auth(self, auth):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -586,3 +586,6 @@ def test_resource_public(resource):
     assert resource.system_metadata()['public'] is True
     resource.set_sharing_status(public=False)
     assert resource.system_metadata()['public'] is False
+
+def test_instantiate_hydroshare_object_without_args():
+    HydroShare()


### PR DESCRIPTION
fixes #41 

Creating `HydroShareSession` object no longer requires some form of authentication. I believe I introduced this issue in e5b16ca.
