### PR TITLE
hsmodels version requirement updated to latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(include=['hsclient', 'hsclient.*'],
                            exclude=("tests",)),
     install_requires=[
-        'hsmodels>=1.0.3',
+        'hsmodels>=1.0.4',
         'requests',
         'requests_oauthlib',
     ],


### PR DESCRIPTION
Current version of hsmodels is 1.0.4. hsclient needs to use this version for installation. 