### PR TITLE
Avoid pkg_resources for package version

### DIFF
--- a/hsclient/hydroshare.py
+++ b/hsclient/hydroshare.py
@@ -11,6 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 from datetime import datetime
 from functools import wraps
+from importlib.metadata import version
 from posixpath import basename, dirname, join as urljoin, splitext
 from pprint import pformat
 from typing import Callable, Dict, List, TYPE_CHECKING, Union
@@ -53,8 +54,7 @@ from hsclient.json_models import ResourcePreview, User
 from hsclient.oauth2_model import Token
 from hsclient.utils import attribute_filter, encode_resource_url, is_aggregation, main_file_type
 
-import pkg_resources  # part of setuptools
-VERSION = pkg_resources.get_distribution(__package__).version
+VERSION = version(__package__)
 
 CHECK_TASK_PING_INTERVAL = 10
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
         'hsmodels>=1.0.4',
         'requests',
         'requests_oauthlib',
-        'setuptools',
     ],
     extras_require={
         "pandas": ["pandas"],


### PR DESCRIPTION
## Summary
- replace `pkg_resources.get_distribution()` with `importlib.metadata.version()` for the hsclient User-Agent version
- remove `setuptools` from runtime install requirements since it is no longer used by the package code

Fixes #101

## Validation
- Not run locally
- `git diff --check HEAD~1..HEAD`
- `rg 'pkg_resources'` (no matches in project files)
- Remote CI: `Run tests and lint` failed during checkout before install/lint/test steps. The workflow tried to check out `fix-101-drop-pkg-resources` from `hydroshare/hsclient`, while this PR branch exists on the fork.